### PR TITLE
LUN-106: Пофиксить API Reactions

### DIFF
--- a/packages/server/api/forum/forumApi.ts
+++ b/packages/server/api/forum/forumApi.ts
@@ -18,6 +18,7 @@ export const forumApi = {
 				data: newForum,
 			};
 		} catch (e) {
+			console.error(e);
 			return {reason: 'Ошибка при создании строки в методе create forum'};
 		}
 	},
@@ -36,6 +37,7 @@ export const forumApi = {
 				data: updatedForum as object,
 			};
 		} catch (e) {
+			console.error(e);
 			return {reason: 'Ошибка при изменении строки в методе rename forum'};
 		}
 	},
@@ -65,6 +67,7 @@ export const forumApi = {
 				data: forums,
 			};
 		} catch (e) {
+			console.error(e);
 			return {reason: 'Ошибка при получении списка форумов в методе list forum'};
 		}
 	},

--- a/packages/server/api/forum/messageApi.ts
+++ b/packages/server/api/forum/messageApi.ts
@@ -38,7 +38,7 @@ const messageWithCountedReactions = (message: TMessagesRespond[0]) => {
 			reaction => reactions.push(reaction.reaction_id));
 		const result: Record<number, number> = {};
 		reactions.forEach(reaction => {
-			if (result[reaction] == undefined) {
+			if (result[reaction] === undefined) {
 				result[reaction] = 0;
 			}
 			result[reaction]++;

--- a/packages/server/api/forum/messageReactionApi.ts
+++ b/packages/server/api/forum/messageReactionApi.ts
@@ -1,6 +1,9 @@
+import {messageApi} from '../forum/messageApi';
 import {MessagesReactions} from '../models';
 import type {TMessageReaction} from '../models';
-import type {TApiResponseData} from '../typing';
+import type {TApiResponseData, TReactionResponse} from '../typing';
+import {sequelize} from '../sequelize';
+import {sequelizeToObject} from '../utils/sequelizeToObject';
 
 // Апи Топика
 export const messageReactionApi = {
@@ -10,15 +13,21 @@ export const messageReactionApi = {
 			return {reason: 'Неправильные параметры для метода set messageReaction'};
 		}
 		try {
-			const newMessageReaction = await MessagesReactions.upsert({
-				message_id,
-				reaction_id,
-				user_id,
-			});
+			const newMessageReaction = await sequelize.query(
+				`INSERT INTO "MessagesReactions" ("message_id", "user_id", "reaction_id")
+				VALUES (${message_id}, ${user_id}, ${reaction_id})
+				ON CONFLICT ("message_id", "user_id") DO
+				UPDATE SET "reaction_id" = ${reaction_id}
+				RETURNING "message_id", "user_id", "reaction_id"`);
+
+			const data = sequelizeToObject<TReactionResponse>(newMessageReaction[0][0]);
+			data.Message = await messageApi.get(message_id, user_id);
+
 			return {
-				data: newMessageReaction,
+				data,
 			};
 		} catch (e) {
+			console.log(e);
 			return {reason: 'Ошибка при создании строки в методе set messageReaction'};
 		}
 	},
@@ -31,8 +40,14 @@ export const messageReactionApi = {
 			const isDeleted = await MessagesReactions.destroy({
 				where: {message_id, user_id},
 			});
+
+			const data: TReactionResponse = {
+				deleted: isDeleted,
+				Message: await messageApi.get(message_id, user_id),
+			};
+
 			return {
-				data: {deleted: isDeleted},
+				data,
 			};
 		} catch (e) {
 			console.error(e);

--- a/packages/server/api/forum/topicApi.ts
+++ b/packages/server/api/forum/topicApi.ts
@@ -1,3 +1,4 @@
+import {sequelizeToObject} from '../utils/sequelizeToObject';
 import {Topics, Messages, Users} from '../models';
 import type {TTopic} from '../models';
 import type {TApiResponseData} from '../typing';
@@ -83,9 +84,7 @@ export const topicApi = {
 				],
 			});
 
-			/** Тут я никак не смог добиться, чтобы в ответе был один объект
-			 * с последним сообщением, поэтому добавил обработку ответа и избавляюсь от массива */
-			const topics = JSON.parse(JSON.stringify(topicsSQL)) as TTopicsRespond;
+			const topics = sequelizeToObject<TTopicsRespond>(topicsSQL) as TTopicsRespond;
 			topics.forEach(topic => {
 				topic['LastMessage'] = topic['Messages'] ? topic['Messages'][0] ?? {} : {};
 				delete topic['Messages'];

--- a/packages/server/api/typing.ts
+++ b/packages/server/api/typing.ts
@@ -17,3 +17,11 @@ export type TApiResponseData = {
 	reason?: string;
 	data?: object;
 };
+
+export type TReactionResponse = {
+	message_id?: number;
+	user_id?: number;
+	reaction_id?: number;
+	deleted?: number;
+	Message: unknown;
+};

--- a/packages/server/api/utils/sequelizeToObject.ts
+++ b/packages/server/api/utils/sequelizeToObject.ts
@@ -1,0 +1,5 @@
+export const sequelizeToObject = <T = object>(
+	sequelizeResponse: any,
+) => {
+	return JSON.parse(JSON.stringify(sequelizeResponse)) as T;
+};


### PR DESCRIPTION
Улучшил создание/обновление реакции.
Ответ апи при изменении реакции теперь такой:
```
{
    "data": {
        "message_id": 5,
        "user_id": 20,
        "reaction_id": 2,
        "Message": {тут полный объект сообщения со всеми реакциями}
    }
}
```

Ответ апи при удалении реакции теперь такой:
```
{
    "data": {
        "deleted": 1,
        "Message": {тут полный объект сообщения со всеми реакциями}
    }
}
```