### PR TITLE
LUN-107: Добавить иконку гитхаба в csp

### DIFF
--- a/packages/client/src/styles/variables.scss
+++ b/packages/client/src/styles/variables.scss
@@ -68,6 +68,7 @@
 	--colorBlueWhite: #ccd4d4;
 	--colorBlueLight: #4a8d92;
 	--colorBlueDark: #161916;
+	--colorBlueTeal: #145778;
 
 	// White
 	--colorWhite: #ccd4d4;

--- a/packages/server/cspMiddleware/index.ts
+++ b/packages/server/cspMiddleware/index.ts
@@ -11,6 +11,7 @@ export const cspMiddleware = () => {
 			'img-src': [
 				SELF,
 				FLAG_ICONS,
+				'\'data:\'',
 			],
 			'font-src': [SELF],
 			'media-src': [SELF],


### PR DESCRIPTION
### Добавление иконки гитхаба в csp

> также добавил цвет в темную тему по просьбе @JennJs 

### Скрин из docker-сборки (там прод)
![image](https://github.com/Lunatics-yp/lunatics/assets/103452841/bc7e2cdf-8d86-48b9-b34d-746668cfa624)
