### PR TITLE
LUN-110: Отметки вокруг уничтоженного модуля

### DIFF
--- a/packages/client/src/game/shooting.ts
+++ b/packages/client/src/game/shooting.ts
@@ -48,6 +48,17 @@ export class Shooting extends GameMechanic {
 		const destroy = (spaceModule: SpaceModule): TShootRespond => {
 			const moduleCoordinates = spaceModule.mapPosition;
 			for (const mapCoordinates of moduleCoordinates) {
+				const {x, y} = mapCoordinates;
+				for (let aroundY = y - 1; aroundY <= y + 1; aroundY++) {
+					for (let aroundX = x - 1; aroundX <= x + 1; aroundX++) {
+						const aroundPosition = {x: aroundX, y: aroundY};
+						if(this.ground.isPositionInsideMap(aroundPosition)){
+							this.ground.setCellStatus(aroundPosition, CellStatus.MISSED);
+						}
+					}
+				}
+			}
+			for (const mapCoordinates of moduleCoordinates) {
 				this.ground.setCellStatus(mapCoordinates, CellStatus.DESTROYED);
 			}
 			return {


### PR DESCRIPTION
Добавил отметки вокруг уничтоженного модуля когда стреляет враг (при стрельбе игрока они уже ставились).

Так же поправил баг, когда игрок мог стрелять по этим отметкам (баг случался, потому что эти отметки ставились только у игрока, а враг на своей карте их не ставил).